### PR TITLE
Bug: Slack API Migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+:warning:
+
+**The upstream project `slack-irc` by Martin Ek is no longer maintained.**
+
+**This fork is been  maintained by [@adamhorden](https://www.github.com/adamhorden) :nerd_face:.**
+
 # slack-irc [![Join the chat at https://gitter.im/ekmartin/slack-irc](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ekmartin/slack-irc?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Build Status](https://travis-ci.org/ekmartin/slack-irc.svg?branch=travis)](https://travis-ci.org/ekmartin/slack-irc) [![Coverage Status](https://coveralls.io/repos/github/ekmartin/slack-irc/badge.svg?branch=master)](https://coveralls.io/github/ekmartin/slack-irc?branch=master)
 
 > Connects Slack and IRC channels by sending messages back and forth. Read more [here](https://ekmartin.com/2015/slack-irc).

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -254,27 +254,30 @@ class Bot {
         return;
       }
 
-      const currentChannelUsernames = slackChannel.members.map(member =>
-        dataStore.getUserById(member).name
-      );
+      this.slack.web.conversations.members(slackChannel.id).then( resp => {
+        const currentChannelUsernames = resp.members.map(member =>
+          dataStore.getUserById(member).name
+        );
 
-      const mappedText = currentChannelUsernames.reduce((current, username) =>
-        highlightUsername(username, current)
-      , text);
+        const mappedText = currentChannelUsernames.reduce((current, username) =>
+          highlightUsername(username, current)
+        , text);
 
-      let iconUrl;
-      if (author !== this.nickname && this.avatarUrl) {
-        iconUrl = this.avatarUrl.replace(/\$username/g, author);
-      }
+        let iconUrl;
+        if (author !== this.nickname && this.avatarUrl) {
+          iconUrl = this.avatarUrl.replace(/\$username/g, author);
+        }
 
-      const options = {
-        username: this.slackUsernameFormat.replace(/\$username/g, author),
-        parse: 'full',
-        icon_url: iconUrl
-      };
+        const options = {
+          username: this.slackUsernameFormat.replace(/\$username/g, author),
+          parse: 'full',
+          icon_url: iconUrl
+        };
 
-      logger.debug('Sending message to Slack', mappedText, channel, '->', slackChannelName);
-      this.slack.web.chat.postMessage(slackChannel.id, mappedText, options);
+        logger.debug('Sending message to Slack', mappedText, channel, '->', slackChannelName);
+        this.slack.web.chat.postMessage(slackChannel.id, mappedText, options);
+
+      });
     }
   }
 }


### PR DESCRIPTION
**bug/slack_api**

Fix bug introduced by Slack API changes 🤓 💥 .

```javascript
/usr/lib/node_modules/slack-irc/node_modules/irc/lib/irc.js:849
                        throw err;
                        ^

TypeError: Cannot read property 'map' of undefined
    at Bot.sendToSlack (/usr/lib/node_modules/slack-irc/dist/bot.js:295:60)
    at emitMany (events.js:147:13)
    at Client.emit (events.js:224:7)
    at Client.<anonymous> (/usr/lib/node_modules/slack-irc/node_modules/irc/lib/irc.js:557:22)
    at emitOne (events.js:116:13)
    at Client.emit (events.js:211:7)
    at iterator (/usr/lib/node_modules/slack-irc/node_modules/irc/lib/irc.js:846:26)
    at Array.forEach (<anonymous>)
    at Socket.handleData (/usr/lib/node_modules/slack-irc/node_modules/irc/lib/irc.js:841:15)
    at emitOne (events.js:116:13)
    at Socket.emit (events.js:211:7)
    at addChunk (_stream_readable.js:263:12)
    at readableAddChunk (_stream_readable.js:246:13)
    at Socket.Readable.push (_stream_readable.js:208:10)
    at TCP.onread (net.js:601:20)
   ```

Signed-off-by: Adam Horden [adam.horden@horden.engineering](mailto:adam.horden@horden.engineering)